### PR TITLE
feat: 검색 조회 API 연동 및 무한스크롤, zustand 설치

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,12 +16,15 @@
     "@tanstack/react-query-devtools": "^5.85.3",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
+    "react-intersection-observer": "^9.16.0",
     "react-router-dom": "^7.8.1",
-    "tailwindcss": "^4.1.12"
+    "tailwindcss": "^4.1.12",
+    "zustand": "^5.0.8"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",
     "@tanstack/eslint-plugin-query": "^5.83.1",
+    "@types/node": "^24.3.0",
     "@types/react": "^19.1.10",
     "@types/react-dom": "^19.1.7",
     "@vitejs/plugin-react": "^5.0.0",

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,17 +1,12 @@
-import { QueryClientProvider } from '@tanstack/react-query';
-import { QueryClient } from '@tanstack/react-query';
-import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { RouterProvider } from 'react-router-dom';
 import { router } from '@app/providers/router';
-
-const queryClient = new QueryClient();
+import QueryProvider from '@app/providers/queryClient';
 
 function App() {
   return (
-    <QueryClientProvider client={queryClient}>
-      <ReactQueryDevtools initialIsOpen={false} />
+    <QueryProvider>
       <RouterProvider router={router} />
-    </QueryClientProvider>
+    </QueryProvider>
   );
 }
 

--- a/src/app/layout/RootLayout.tsx
+++ b/src/app/layout/RootLayout.tsx
@@ -5,9 +5,9 @@ export default function RootLayout() {
   return (
     <>
       <Header />
-      <div className="container mx-auto pt-40 pb-36">
+      <main className="container mx-auto pt-40 pb-36">
         <Outlet />
-      </div>
+      </main>
     </>
   );
 }

--- a/src/app/pages/BookSearchPage.tsx
+++ b/src/app/pages/BookSearchPage.tsx
@@ -1,11 +1,44 @@
+// BookSearchPage.tsx
+import { useState } from 'react';
 import SearchSection from '@features/books/components/SearchSection';
 import BookSection from '@features/books/components/BookSection';
+import { useBooksInfinite } from '@features/books/hooks/useBooksInfinite';
 
 export default function BookSearchPage() {
+  // TODO: 디바운싱 적용
+  const [searchInput, setSearchInput] = useState('');
+  const [keyword, setKeyword] = useState('');
+
+  const [target, setTarget] = useState<string | null>(null);
+  const [openFilter, setOpenFilter] = useState(false);
+
+  const { query, ref } = useBooksInfinite({
+    query: keyword,
+    size: 10,
+    page: 1,
+  });
+
+  const books = query.data?.pages.flatMap((p) => p.documents ?? []) ?? [];
+  const meta = query.data?.pages[0]?.meta;
+  const hasNextPage = query.hasNextPage;
+
+  const handleSubmitSearch = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setKeyword(searchInput.trim());
+  };
+
   return (
     <>
-      <SearchSection />
-      <BookSection />
+      <form onSubmit={handleSubmitSearch}>
+        <SearchSection
+          searchInput={searchInput}
+          setSearchInput={setSearchInput}
+        />
+      </form>
+      <BookSection books={books} total={meta?.total_count ?? 0} />
+      {books.length > 0 && hasNextPage && (
+        <div ref={ref} className="w-full h-px" />
+      )}
     </>
   );
 }

--- a/src/app/pages/BookSearchPage.tsx
+++ b/src/app/pages/BookSearchPage.tsx
@@ -1,4 +1,3 @@
-// BookSearchPage.tsx
 import { useState } from 'react';
 import SearchSection from '@features/books/components/SearchSection';
 import BookSection from '@features/books/components/BookSection';
@@ -9,6 +8,7 @@ export default function BookSearchPage() {
   const [searchInput, setSearchInput] = useState('');
   const [keyword, setKeyword] = useState('');
 
+  // TODO: 검색 필터 연동
   const [target, setTarget] = useState<string | null>(null);
   const [openFilter, setOpenFilter] = useState(false);
 
@@ -26,6 +26,8 @@ export default function BookSearchPage() {
     e.preventDefault();
     setKeyword(searchInput.trim());
   };
+
+  // TODO: 로딩 상태 처리
 
   return (
     <>

--- a/src/app/pages/BookSearchPage.tsx
+++ b/src/app/pages/BookSearchPage.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import SearchSection from '@features/books/components/SearchSection';
 import BookSection from '@features/books/components/BookSection';
-import { useBooksInfinite } from '@features/books/hooks/useBooksInfinite';
+import { useInfiniteBooks } from '@features/books/hooks/useInfiniteBooks';
 
 export default function BookSearchPage() {
   // TODO: 디바운싱 적용
@@ -12,7 +12,7 @@ export default function BookSearchPage() {
   const [target, setTarget] = useState<string | null>(null);
   const [openFilter, setOpenFilter] = useState(false);
 
-  const { query, ref } = useBooksInfinite({
+  const { query, ref } = useInfiniteBooks({
     query: keyword,
     size: 10,
     page: 1,

--- a/src/app/providers/queryClient.tsx
+++ b/src/app/providers/queryClient.tsx
@@ -1,0 +1,43 @@
+import {
+  QueryClient,
+  QueryClientProvider,
+  QueryCache,
+  MutationCache,
+} from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+
+const queryClient = new QueryClient({
+  queryCache: new QueryCache({
+    onError: (error) => {
+      alert('Query Error: ' + error.message);
+    },
+  }),
+  mutationCache: new MutationCache({
+    onError: (error) => {
+      alert('Mutation Error: ' + error.message);
+    },
+  }),
+  defaultOptions: {
+    queries: {
+      staleTime: 1000 * 60 * 5, // 5분
+      retry: 3,
+      retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000),
+    },
+    mutations: {
+      retry: false,
+    },
+  },
+});
+
+export default function QueryProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <ReactQueryDevtools initialIsOpen={false} buttonPosition="bottom-left" />
+      {children}
+    </QueryClientProvider>
+  );
+}

--- a/src/features/books/api/getBooks.ts
+++ b/src/features/books/api/getBooks.ts
@@ -1,0 +1,24 @@
+import type { BooksParams } from '@features/books/types/book';
+
+export default async function getBooks({
+  query = '',
+  page = 1,
+  size = 10,
+}: BooksParams) {
+  const params = new URLSearchParams({
+    query,
+    page: String(page),
+    size: String(size),
+  });
+
+  const res = await fetch(
+    `${import.meta.env.VITE_KAKAO_API_URL}/search/book?${params.toString()}`,
+    {
+      headers: {
+        Authorization: `KakaoAK ${import.meta.env.VITE_KAKAO_REST_API_KEY}`,
+      },
+    }
+  );
+
+  return await res.json();
+}

--- a/src/features/books/components/BookItem.tsx
+++ b/src/features/books/components/BookItem.tsx
@@ -4,14 +4,21 @@ import { twMerge } from 'tailwind-merge';
 import DropIcon from '@assets/icons/icon_arrow_14.svg?react';
 // import LikeFillIcon from '@assets/icons/icon_like_fill.svg?react';
 import LikeLineIcon from '@assets/icons/icon_like_line.svg?react';
+import type { Book } from '@features/books/types/book';
 
-export default function BookItem() {
+interface BookItemProps {
+  book: Book;
+}
+
+export default function BookItem({ book }: BookItemProps) {
   const [open, setOpen] = useState(false);
 
   const containerClass = twMerge(
     'flex justify-between gap-14 pl-12 pr-4  border-b border-border',
     open ? 'items-stretch pt-6 pb-[40px]' : 'items-center py-4'
   );
+
+  const { thumbnail, title, price, sale_price } = book;
 
   return (
     <li className={containerClass}>
@@ -21,15 +28,28 @@ export default function BookItem() {
           open ? 'items-start' : 'items-center'
         )}
       >
-        <BookImage open={open} />
-        <Info open={open} />
+        <BookImage open={open} title={title} thumbnail={thumbnail} />
+        <BookInfo open={open} book={book} />
       </div>
-      <Actions open={open} setOpen={setOpen} />
+      <Actions
+        open={open}
+        setOpen={setOpen}
+        price={price}
+        salePrice={sale_price}
+      />
     </li>
   );
 }
 
-function BookImage({ open }: { open: boolean }) {
+function BookImage({
+  open,
+  title,
+  thumbnail,
+}: {
+  open: boolean;
+  title: string;
+  thumbnail: string;
+}) {
   const imageClass = twMerge(
     'overflow-hidden relative',
     open ? 'w-[210px] h-[280px]' : 'w-[48px] h-[68px]'
@@ -42,11 +62,7 @@ function BookImage({ open }: { open: boolean }) {
 
   return (
     <div className={imageClass}>
-      <img
-        src="https://dummyimage.com/210x280/000/8affad"
-        alt="책 표지"
-        className="w-full h-full object-cover"
-      />
+      <img src={thumbnail} alt={title} className="w-full h-full object-cover" />
       <button type="button" aria-label="책 찜하기">
         {/* <LikeFillIcon/> */}
         <LikeLineIcon className={likeButtonClass} />
@@ -55,32 +71,37 @@ function BookImage({ open }: { open: boolean }) {
   );
 }
 
-function Info({ open }: { open: boolean }) {
+function BookInfo({ open, book }: { open: boolean; book: Book }) {
+  const { title, authors, contents, price, sale_price } = book;
   const infoClass = twMerge(
     'flex-1 flex',
     open
       ? 'flex-col items-start pt-8 pl-[20px]'
-      : 'flex-row items-center justify-between'
+      : 'flex-row items-center justify-between gap-6'
   );
 
   return (
     <div className={infoClass}>
       <div className="flex items-center gap-4">
-        <h3 className="t-title-3">노르웨이의 숲</h3>
-        <p className="t-body-2 text-text-secondary">무라카미 하루키</p>
+        <h3 className="t-title-3">{title}</h3>
+        <p className="t-body-2 text-text-secondary whitespace-nowrap">
+          {authors.join(', ')}
+        </p>
       </div>
 
       {open ? (
         <div className="mt-4">
           <h4 className="text-sm font-bold">책 소개</h4>
           <p className="mt-3 text-medium t-small whitespace-pre-line leading-4">
-            {`하루키 월드의 빛나는 다이아몬드 무라카미 하루키를 만나기 위해
-              하루키 월드의 빛나는 다이아몬드 무라카미 하루키를 만나기 위해
-              하루키 월드의 빛나는 다이아몬드 무라카미 하루키를 만나기 위해`}
+            {contents || '책 소개가 없습니다.'}
           </p>
         </div>
       ) : (
-        <span className="t-title-3">13,300원</span>
+        <span className="t-title-3 whitespace-nowrap">
+          {sale_price > 0
+            ? `${sale_price.toLocaleString()}원`
+            : `${price.toLocaleString()}원`}
+        </span>
       )}
     </div>
   );
@@ -89,13 +110,22 @@ function Info({ open }: { open: boolean }) {
 function Actions({
   open,
   setOpen,
+  price,
+  salePrice,
 }: {
   open: boolean;
   setOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  price: number;
+  salePrice: number;
 }) {
   const actionsClass = twMerge(
     'flex',
     open ? 'flex-col justify-between items-end' : 'items-center gap-2'
+  );
+
+  const priceClass = twMerge(
+    'text-lg ',
+    salePrice > 0 ? 'font-light line-through' : 'font-bold'
   );
 
   return (
@@ -117,12 +147,16 @@ function Actions({
           <ul className="space-y-2">
             <li className="flex items-baseline justify-end gap-2">
               <span className="text-text-subtitle t-small">원가</span>
-              <span className="text-lg line-through font-light">16,000원</span>
+              <span className={priceClass}>{price.toLocaleString()}원</span>
             </li>
-            <li className="flex items-baseline justify-end gap-2">
-              <span className="text-text-subtitle t-small">할인가</span>
-              <span className="text-lg font-bold">16,000원</span>
-            </li>
+            {salePrice > 0 && (
+              <li className="flex items-baseline justify-end gap-2">
+                <span className="text-text-subtitle t-small">할인가</span>
+                <span className="text-lg font-bold">
+                  {salePrice.toLocaleString()}원
+                </span>
+              </li>
+            )}
           </ul>
           <Button label="구매하기" className="w-[240px]" />
         </div>

--- a/src/features/books/components/BookList.tsx
+++ b/src/features/books/components/BookList.tsx
@@ -1,10 +1,16 @@
 import BookItem from './BookItem';
+import type { Book } from '@features/books/types/book';
 
-export default function BookList() {
+interface BookListProps {
+  books?: Book[];
+}
+
+export default function BookList({ books = [] }: BookListProps) {
   return (
     <ul>
-      <BookItem />
-      <BookItem />
+      {books.map((book) => (
+        <BookItem key={book.isbn} book={book} />
+      ))}
     </ul>
   );
 }

--- a/src/features/books/components/BookSection.tsx
+++ b/src/features/books/components/BookSection.tsx
@@ -1,14 +1,23 @@
 import EmptyState from '@shared/ui/EmptyState';
 import ResultSummary from '@shared/ui/ResultSummary';
 import BookList from '@features/books/components/BookList';
+import type { Book } from '@features/books/types/book';
 
-export default function BookSection() {
+interface BookSectionProps {
+  books: Book[];
+  total: number;
+}
+
+export default function BookSection({ books = [], total }: BookSectionProps) {
   return (
     <section className="mt-6">
-      <ResultSummary total={0} />
+      <ResultSummary total={total} label="도서 검색 결과" />
       <div className="mt-9">
-        <BookList />
-        <EmptyState />
+        {books && books.length > 0 ? (
+          <BookList books={books} />
+        ) : (
+          <EmptyState message="검색 결과가 없습니다." />
+        )}
       </div>
     </section>
   );

--- a/src/features/books/components/SearchBar.tsx
+++ b/src/features/books/components/SearchBar.tsx
@@ -2,7 +2,15 @@ import { useEffect, useRef, useState } from 'react';
 import SearchIcon from '@assets/icons/icon_search.svg?react';
 import CloseIcon from '@assets/icons/icon_close_24.svg?react';
 
-export default function SearchBar() {
+interface SearchBarProps {
+  searchInput: string;
+  setSearchInput: React.Dispatch<React.SetStateAction<string>>;
+}
+
+export default function SearchBar({
+  searchInput,
+  setSearchInput,
+}: SearchBarProps) {
   const [open, setOpen] = useState(false);
   const listRef = useRef<HTMLUListElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -10,7 +18,6 @@ export default function SearchBar() {
   useEffect(() => {
     if (!open) return;
     const onKey = (e: KeyboardEvent) => {
-      // ESC 키를 누르면 닫히도록 처리
       if (e.key === 'Escape') {
         setOpen(false);
         inputRef.current?.blur();
@@ -27,6 +34,7 @@ export default function SearchBar() {
         <input
           ref={inputRef}
           type="text"
+          value={searchInput}
           placeholder="검색어를 입력하세요"
           aria-expanded={open}
           aria-controls="search-suggestion-list"
@@ -35,6 +43,16 @@ export default function SearchBar() {
             const next = e.relatedTarget as HTMLElement | null;
             if (next && listRef.current?.contains(next)) return;
             setOpen(false);
+          }}
+          onChange={(e) => setSearchInput(e.target.value)}
+          onKeyDown={(e) => {
+            const isEnter = e.key === 'Enter';
+            const isComposing = e.nativeEvent.isComposing;
+            if (isEnter && !isComposing) {
+              e.preventDefault();
+
+              e.currentTarget.form?.requestSubmit();
+            }
           }}
           className="w-full h-[50px] pl-13 py-4 pr-4 bg-lightgray t-caption placeholder:text-text-subtitle rounded-t-3xl rounded-b-[var(--rounded-b)] focus:outline-none"
           style={{ ['--rounded-b' as string]: open ? '0px' : '24px' }}
@@ -45,15 +63,18 @@ export default function SearchBar() {
         <ul
           id="search-suggestion-list"
           ref={listRef}
-          role="searchList"
+          role="listbox"
           onMouseDown={(e) => e.preventDefault()}
           className="absolute z-10 w-full rounded-b-3xl bg-lightgray py-4 pl-13 pr-6"
         >
-          <li
-            className="flex items-center justify-between py-2"
-            role="searchOption"
-          >
-            <span className="t-caption text-text-subtitle">노르웨이 숲</span>
+          <li className="flex items-center justify-between py-2" role="option">
+            <button
+              type="button"
+              className="t-caption text-text-subtitle text-left w-full"
+              onClick={() => {}}
+            >
+              노르웨이 숲
+            </button>
             <button
               type="button"
               aria-label="검색어 삭제"

--- a/src/features/books/components/SearchFilter.tsx
+++ b/src/features/books/components/SearchFilter.tsx
@@ -3,7 +3,15 @@ import { useState } from 'react';
 import Button from '@shared/ui/button';
 import SearchFilterPanel from '@features/books/components/SearchFilterPanel';
 
-export default function SearchFilter() {
+interface SearchFilterProps {
+  searchInput: string;
+  setSearchInput: React.Dispatch<React.SetStateAction<string>>;
+}
+
+export default function SearchFilter({
+  searchInput,
+  setSearchInput,
+}: SearchFilterProps) {
   const [openFilter, setOpenFilter] = useState(false);
 
   return (
@@ -15,7 +23,12 @@ export default function SearchFilter() {
         className="p-2.5"
         onClick={() => setOpenFilter((prev) => !prev)}
       />
-      <SearchFilterPanel open={openFilter} setOpen={setOpenFilter} />
+      <SearchFilterPanel
+        open={openFilter}
+        setOpen={setOpenFilter}
+        searchInput={searchInput}
+        setSearchInput={setSearchInput}
+      />
     </div>
   );
 }

--- a/src/features/books/components/SearchFilterPanel.tsx
+++ b/src/features/books/components/SearchFilterPanel.tsx
@@ -6,11 +6,15 @@ import Input from '@shared/ui/input';
 interface SearchFilterPanelProps {
   open: boolean;
   setOpen: (open: boolean) => void;
+  searchInput: string;
+  setSearchInput: React.Dispatch<React.SetStateAction<string>>;
 }
 
 export default function SearchFilterPanel({
   open,
   setOpen,
+  searchInput,
+  setSearchInput,
 }: SearchFilterPanelProps) {
   return (
     <aside
@@ -36,9 +40,14 @@ export default function SearchFilterPanel({
             { label: 'ISBN', value: 'isbn' },
           ]}
         />
-        <Input className="flex-1" />
+        <Input
+          className="flex-1"
+          value={searchInput}
+          onChange={(e) => setSearchInput(e.target.value)}
+        />
       </div>
       <Button
+        type="submit"
         label="검색하기"
         typography="body2"
         className="w-full py-[7px] h-9"

--- a/src/features/books/components/SearchSection.tsx
+++ b/src/features/books/components/SearchSection.tsx
@@ -1,13 +1,24 @@
 import SearchBar from '@features/books/components/SearchBar';
 import SearchFilter from '@features/books/components/SearchFilter';
 
-export default function SearchSection() {
+interface SearchSectionProps {
+  searchInput: string;
+  setSearchInput: React.Dispatch<React.SetStateAction<string>>;
+}
+
+export default function SearchSection({
+  searchInput,
+  setSearchInput,
+}: SearchSectionProps) {
   return (
     <section>
       <h2 className="t-title-2">도서 검색</h2>
       <div className="flex items-center gap-4 w-[568px] mt-4">
-        <SearchBar />
-        <SearchFilter />
+        <SearchBar searchInput={searchInput} setSearchInput={setSearchInput} />
+        <SearchFilter
+          searchInput={searchInput}
+          setSearchInput={setSearchInput}
+        />
       </div>
     </section>
   );

--- a/src/features/books/hooks/useBooksInfinite.ts
+++ b/src/features/books/hooks/useBooksInfinite.ts
@@ -1,0 +1,28 @@
+import { useMemo } from 'react';
+import getBooks from '@features/books/api/getBooks';
+import type { BookResponse, BooksParams } from '@features/books/types/book';
+import { useInfiniteQueryScroll } from '@shared/hooks/useInfiniteQueryScroll';
+
+export function useBooksInfinite({
+  query = '',
+  size = 10,
+  page = 1,
+  sort = 'accuracy',
+  target,
+}: BooksParams) {
+  const initial = useMemo<BooksParams>(
+    () => ({ query, page, size, sort, target }),
+    [query, page, size, sort, target]
+  );
+
+  return useInfiniteQueryScroll<BookResponse>({
+    queryKey: ['books', query, size, sort, target],
+    initialPageParam: initial,
+    enabled: true,
+    queryFn: ({ pageParam }) => getBooks(pageParam),
+    getNextPageParam: (lastPage, allPages) => {
+      if (lastPage?.meta?.is_end) return undefined;
+      return { ...initial, page: allPages.length + 1 };
+    },
+  });
+}

--- a/src/features/books/hooks/useInfiniteBooks.ts
+++ b/src/features/books/hooks/useInfiniteBooks.ts
@@ -3,7 +3,7 @@ import getBooks from '@features/books/api/getBooks';
 import type { BookResponse, BooksParams } from '@features/books/types/book';
 import { useInfiniteQueryScroll } from '@shared/hooks/useInfiniteQueryScroll';
 
-export function useBooksInfinite({
+export function useInfiniteBooks({
   query = '',
   size = 10,
   page = 1,

--- a/src/features/books/types/book.ts
+++ b/src/features/books/types/book.ts
@@ -1,0 +1,32 @@
+type BooksParams = {
+  query: string;
+  page: number;
+  size: number;
+  sort?: 'accuracy' | 'latest';
+  target?: 'title' | 'isbn' | 'publisher' | 'person';
+};
+
+type BookResponse = {
+  documents: Book[];
+  meta: {
+    pageable_count: number;
+    total_count: number;
+    is_end: boolean;
+  };
+};
+
+type Book = {
+  title: string;
+  contents: string;
+  url: string;
+  isbn: string;
+  datetime: Date;
+  authors: string[];
+  publisher: string;
+  thumbnail: string;
+  status: string;
+  price: number;
+  sale_price: number;
+};
+
+export type { BooksParams, BookResponse, Book };

--- a/src/shared/hooks/useInfiniteQueryScroll.ts
+++ b/src/shared/hooks/useInfiniteQueryScroll.ts
@@ -1,0 +1,48 @@
+import { useEffect } from 'react';
+import { useInView } from 'react-intersection-observer';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import type { QueryKey } from '@tanstack/react-query';
+import type { BooksParams } from '@features/books/types/book';
+
+type UseQueryInfiniteScrollOptions<T> = {
+  queryKey: QueryKey;
+  queryFn: (ctx: { pageParam: BooksParams }) => Promise<T>;
+  getNextPageParam: (lastPage: T, allPages: T[]) => BooksParams | undefined;
+  enabled?: boolean;
+  initialPageParam: BooksParams;
+};
+
+export function useInfiniteQueryScroll<T>({
+  queryKey,
+  queryFn,
+  getNextPageParam,
+  enabled = true,
+  initialPageParam,
+}: UseQueryInfiniteScrollOptions<T>) {
+  const { ref, inView } = useInView({
+    rootMargin: '200px 0px',
+    threshold: 0.1,
+  });
+
+  const query = useInfiniteQuery({
+    queryKey,
+    queryFn: ({ pageParam }) => queryFn({ pageParam }),
+    initialPageParam,
+    getNextPageParam,
+    enabled,
+  });
+
+  const { hasNextPage, isFetchingNextPage, fetchNextPage } = query;
+
+  useEffect(() => {
+    if (!enabled) return;
+    if (inView && hasNextPage && !isFetchingNextPage) {
+      fetchNextPage();
+    }
+  }, [inView, enabled, hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  return {
+    query,
+    ref,
+  };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1721,6 +1721,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/node@npm:^24.3.0":
+  version: 24.3.0
+  resolution: "@types/node@npm:24.3.0"
+  dependencies:
+    undici-types: "npm:~7.10.0"
+  checksum: 10c0/96bdeca01f690338957c2dcc92cb9f76c262c10398f8d91860865464412b0f9d309c24d9b03d0bdd26dd47fa7ee3f8227893d5c89bc2009d919a525a22512030
+  languageName: node
+  linkType: hard
+
 "@types/react-dom@npm:^19.1.7":
   version: 19.1.7
   resolution: "@types/react-dom@npm:19.1.7"
@@ -2082,6 +2091,7 @@ __metadata:
     "@tanstack/eslint-plugin-query": "npm:^5.83.1"
     "@tanstack/react-query": "npm:^5.85.3"
     "@tanstack/react-query-devtools": "npm:^5.85.3"
+    "@types/node": "npm:^24.3.0"
     "@types/react": "npm:^19.1.10"
     "@types/react-dom": "npm:^19.1.7"
     "@vitejs/plugin-react": "npm:^5.0.0"
@@ -2092,6 +2102,7 @@ __metadata:
     prettier: "npm:^3.6.2"
     react: "npm:^19.1.1"
     react-dom: "npm:^19.1.1"
+    react-intersection-observer: "npm:^9.16.0"
     react-router-dom: "npm:^7.8.1"
     tailwind-merge: "npm:^3.3.1"
     tailwindcss: "npm:^4.1.12"
@@ -2100,6 +2111,7 @@ __metadata:
     vite: "npm:^7.1.2"
     vite-plugin-svgr: "npm:^4.3.0"
     vite-tsconfig-paths: "npm:^5.1.4"
+    zustand: "npm:^5.0.8"
   languageName: unknown
   linkType: soft
 
@@ -3594,6 +3606,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-intersection-observer@npm:^9.16.0":
+  version: 9.16.0
+  resolution: "react-intersection-observer@npm:9.16.0"
+  peerDependencies:
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    react-dom:
+      optional: true
+  checksum: 10c0/2aee5103fb460c6e5a3ab5a4fdc8c69a5215e23699a12d7857f25ba765fed48eacbed94ca835d79edf00c0edcc9c4fbb5bb057a373402d0551718546810e0e48
+  languageName: node
+  linkType: hard
+
 "react-refresh@npm:^0.17.0":
   version: 0.17.0
   resolution: "react-refresh@npm:0.17.0"
@@ -4099,6 +4124,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"undici-types@npm:~7.10.0":
+  version: 7.10.0
+  resolution: "undici-types@npm:7.10.0"
+  checksum: 10c0/8b00ce50e235fe3cc601307f148b5e8fb427092ee3b23e8118ec0a5d7f68eca8cee468c8fc9f15cbb2cf2a3797945ebceb1cbd9732306a1d00e0a9b6afa0f635
+  languageName: node
+  linkType: hard
+
 "unique-filename@npm:^4.0.0":
   version: 4.0.0
   resolution: "unique-filename@npm:4.0.0"
@@ -4331,5 +4363,26 @@ __metadata:
   version: 0.1.0
   resolution: "yocto-queue@npm:0.1.0"
   checksum: 10c0/dceb44c28578b31641e13695d200d34ec4ab3966a5729814d5445b194933c096b7ced71494ce53a0e8820685d1d010df8b2422e5bf2cdea7e469d97ffbea306f
+  languageName: node
+  linkType: hard
+
+"zustand@npm:^5.0.8":
+  version: 5.0.8
+  resolution: "zustand@npm:5.0.8"
+  peerDependencies:
+    "@types/react": ">=18.0.0"
+    immer: ">=9.0.6"
+    react: ">=18.0.0"
+    use-sync-external-store: ">=1.2.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    immer:
+      optional: true
+    react:
+      optional: true
+    use-sync-external-store:
+      optional: true
+  checksum: 10c0/e865a6f7f1c0e03571701db5904151aaa7acefd6f85541a117085e129bf16e8f60b11f8cc82f277472de5c7ad5dcb201e1b0a89035ea0b40c9d9aab3cd24c8ad
   languageName: node
   linkType: hard


### PR DESCRIPTION
## 작업 내용
- 검색창 입력 시 책 조회 API 연동 (필터 제외)
- 무한스크롤 적용 - useInfiniteBooks
- useInfiniteQuerySrcoll 공통으로 쓸 수 있는 훅 추가
- zustand 설치

## 리팩토링 포인트
- 현재 검색 페이지 에서 쓰이는 데이터들을 계속 Props로 넘겨 줘야함.